### PR TITLE
Propagate events with state for feedbacks

### DIFF
--- a/Example/UnifiedStoreUIKitExample/UnifiedStore.swift
+++ b/Example/UnifiedStoreUIKitExample/UnifiedStore.swift
@@ -22,13 +22,19 @@ enum UnifiedStore {
         )
     )
 
-    private static let feedbacks: Loop<State, Event>.Feedback = Loop<State, Event>.Feedback.combine(
-        Loop<State, Event>.Feedback.pullback(
-            feedback: Movies.feedback,
+    private static let feedbacks: Loop<State, Event>.Feedback = Movies.feedback
+        .pullback(
             value: \.movies,
-            event: Event.movies
+            embedEvent: Event.movies,
+            extractEvent: { (event) -> Movies.Event? in
+                switch event {
+                case let .movies(moviesEvent):
+                    return moviesEvent
+                default:
+                    return nil
+                }
+            }
         )
-    )
 }
 
 extension UnifiedStore {

--- a/Loop/Public/FeedbackLoop.swift
+++ b/Loop/Public/FeedbackLoop.swift
@@ -81,7 +81,7 @@ extension Loop {
         ///             and having them consumed by `output` using the `SignalProducer.enqueue(to:)` operator.
         public init(
             events: @escaping (
-                _ state: SignalProducer<(State, Event?), Never>,
+                _ statesAndEvents: SignalProducer<(State, Event?), Never>,
                 _ output: FeedbackEventConsumer<Event>
             ) -> SignalProducer<Never, Never>
         ) {

--- a/LoopTests/FeedbackLoopSystemTests.swift
+++ b/LoopTests/FeedbackLoopSystemTests.swift
@@ -364,4 +364,54 @@ class FeedbackLoopSystemTests: XCTestCase {
         expect(results) == [0, 1, 3, 6]
         expect(events) == [1, 2, 3]
     }
+
+    func test_events_of_feedback_emitted_in_correct_order() {
+        let (feedback, input) = Loop<Int, Int>.Feedback.input
+        var events: [Int] = []
+        var result: [(Int, Int?)] = []
+        let system = SignalProducer<Int, Never>.feedbackLoop(
+            initial: 0,
+            reduce: { (state: inout Int, event: Int) in
+                events.append(event)
+                state += event
+            },
+            feedbacks: [
+                feedback,
+                Loop.Feedback.init(events: { (stateAndEvents, consumer) -> SignalProducer<Never, Never> in
+                    stateAndEvents.on(value: {
+                        result.append($0)
+                    })
+                    .flatMap(.latest) { _ -> SignalProducer<Never, Never> in
+                        return SignalProducer<Int, Never>.empty
+                            .enqueue(to: consumer)
+                    }
+                })
+            ]
+        )
+
+        var states: [Int] = []
+
+        system.startWithValues { value in
+            states.append(value)
+        }
+
+        input(1)
+        input(2)
+        input(3)
+
+        expect(states) == [0, 1, 3, 6]
+        XCTAssertTrue(result.map(Tuple2.init) == [Tuple2(0, nil), Tuple2(1, 1), Tuple2(3, 2), Tuple2(6, 3)])
+    }
 }
+
+struct Tuple2<T, U> {
+    let a: T
+    let b: U
+
+    init(_ a: T, _ b: U) {
+        self.a = a
+        self.b = b
+    }
+}
+
+extension Tuple2: Equatable where T: Equatable, U: Equatable {}

--- a/LoopTests/FeedbackLoopSystemTests.swift
+++ b/LoopTests/FeedbackLoopSystemTests.swift
@@ -320,6 +320,7 @@ class FeedbackLoopSystemTests: XCTestCase {
                             // `state` is NOT GUARANTEED to reflect events emitted earlier in the producer chain.
                             state
                                 .take(first: 3)
+                                .map(\.0)
                                 .map { $0 + 1000 }
                         )
                         .enqueue(to: output)


### PR DESCRIPTION
Per #5 

Resurrecting old proposal from @inamiy https://github.com/babylonhealth/ReactiveFeedback/pull/41

This is an **additive change** to add `Optional<Event>` argument in `Feedback` so that unnecessary intermediate states will no longer be required.

Event-driven feedback will be useful for following scenarios, without needing to add a new state and then transit (and transit back again):
 
- Logging
- Analytics
- Routing
- Image loader (but not managing its internal states)

This is a change **from Moore model to (kind of) Mealy model** as discussed in https://github.com/Babylonpartners/ReactiveFeedback/pull/32#pullrequestreview-218703551 .

Please note that `reducer` and `feedback` are still in sequence, not parallel.

Also, please note that `Optional<Event>` is used here as a workaround since it requires more breaking changes to minimize into non-optional `Event`.