### PR TITLE
Fix a deadlock when `Loop.producer` is started recursively.

### DIFF
--- a/Loop/Floodgate.swift
+++ b/Loop/Floodgate.swift
@@ -23,7 +23,8 @@ final class Floodgate<State, Event>: FeedbackEventConsumer<Event> {
         }
     }
 
-    private let reducerLock = NSLock()
+    private let reducerLock = RecursiveLock()
+
     private var state: State
     private var hasStarted = false
 
@@ -40,13 +41,14 @@ final class Floodgate<State, Event>: FeedbackEventConsumer<Event> {
         dispose()
     }
 
-    func bootstrap(with feedbacks: [FeedbackLoop<State, Event>.Feedback]) {
+    func bootstrap(with feedbacks: [Loop<State, Event>.Feedback]) {
         for feedback in feedbacks {
             // Pass `producer` which has replay-1 semantic.
             feedbackDisposables += feedback.events(producer, self)
         }
 
-        reducerLock.perform {
+        reducerLock.perform { reentrant in
+            assert(reentrant == false)
             drainEvents()
         }
     }
@@ -54,32 +56,43 @@ final class Floodgate<State, Event>: FeedbackEventConsumer<Event> {
     override func process(_ event: Event, for token: Token) {
         enqueue(event, for: token)
 
-        if reducerLock.try() {
-            repeat {
+        var continueToDrain = false
+
+        repeat {
+            // We use a recursive lock to guard the reducer, so as to allow state access via `withValue` to be
+            // reentrant. But in order to not deadlock in ReactiveSwift, reentrant calls MUST NOT drain the queue.
+            // Otherwise, `consume(_:)` will eventually invoke the reducer and send out a state via `changeObserver`,
+            // leading to a deadlock.
+            //
+            // If we know that the call is reentrant, we can confidently skip draining the queue anyway, because the
+            // outmost call — the one who first acquires the lock on the current lock owner thread — is already looping
+            // to exhaustively drain the queue.
+            continueToDrain = reducerLock.tryPerform { isReentrant in
+                guard isReentrant == false else { return false }
                 drainEvents()
-                reducerLock.unlock()
-            } while queue.withValue({ $0.hasEvents }) && reducerLock.try()
-            // ^^^
-            // Restart the event draining after we unlock the reducer lock, iff:
-            //
-            // 1. the queue still has unprocessed events; and
-            // 2. no concurrent actor has taken the reducer lock, which implies no event draining would be started
-            //    unless we take active action.
-            //
-            // This eliminates a race condition in the following sequence of operations:
-            //
-            // |              Thread A              |              Thread B              |
-            // |------------------------------------|------------------------------------|
-            // |     concurrent dequeue: no item    |                                    |
-            // |                                    |         concurrent enqueue         |
-            // |                                    |         trylock lock: BUSY         |
-            // |            unlock lock             |                                    |
-            // |                                    |                                    |
-            // |             <<<  The enqueued event is left unprocessed. >>>            |
-            //
-            // The trylock-unlock duo has a synchronize-with relationship, which ensures that Thread A must see any
-            // concurrent enqueue that *happens before* the trylock.
-        }
+                return true
+            }
+        } while queue.withValue({ $0.hasEvents }) && continueToDrain
+        // ^^^
+        // Restart the event draining after we unlock the reducer lock, iff:
+        //
+        // 1. the queue still has unprocessed events; and
+        // 2. no concurrent actor has taken the reducer lock, which implies no event draining would be started
+        //    unless we take active action.
+        //
+        // This eliminates a race condition in the following sequence of operations:
+        //
+        // |              Thread A              |              Thread B              |
+        // |------------------------------------|------------------------------------|
+        // |     concurrent dequeue: no item    |                                    |
+        // |                                    |         concurrent enqueue         |
+        // |                                    |         trylock lock: BUSY         |
+        // |            unlock lock             |                                    |
+        // |                                    |                                    |
+        // |             <<<  The enqueued event is left unprocessed. >>>            |
+        //
+        // The trylock-unlock duo has a synchronize-with relationship, which ensures that Thread A must see any
+        // concurrent enqueue that *happens before* the trylock.
     }
 
     override func dequeueAllEvents(for token: Token) {
@@ -87,7 +100,7 @@ final class Floodgate<State, Event>: FeedbackEventConsumer<Event> {
     }
 
     func withValue<Result>(_ action: (State, Bool) -> Result) -> Result {
-        reducerLock.perform { action(state, hasStarted) }
+        reducerLock.perform { _ in action(state, hasStarted) }
     }
 
     func dispose() {

--- a/Loop/NSLock+Extensions.swift
+++ b/Loop/NSLock+Extensions.swift
@@ -1,10 +1,42 @@
 import Foundation
 
-extension NSLock {
-    internal func perform<Result>(_ action: () -> Result) -> Result {
-        lock()
-        defer { unlock() }
+final class RecursiveLock {
+    let lock = NSRecursiveLock()
+    private var isLockAcquired = false
 
-        return action()
+    init() {}
+
+    /// Try to acquire the lock, perform the given action, and return whether or not the action is successful.
+    ///
+    /// - returns: The boolean flag indicating successfulness as returned by `action`. If the lock cannot be acquired,
+    ///            `false` is returned.
+    @inlinable
+    func tryPerform(_ action: (_ isReentrant: Bool) -> Bool) -> Bool {
+        if lock.try() {
+            defer { lock.unlock() }
+            return run(action)
+        }
+
+        return false
+    }
+
+    /// Acquire the lock, and perform the given action. If the lock is contested, wait until it is free.
+    ///
+    /// - returns: Pass through the value produced by `action`.
+    @inlinable
+    func perform<Result>(_ action: (_ isReentrant: Bool) -> Result) -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return run(action)
+    }
+
+    private func run<Result>(_ action: (_ isReentrant: Bool) -> Result) -> Result {
+        if isLockAcquired {
+            return action(true)
+        } else {
+            isLockAcquired = true
+            defer { isLockAcquired = false }
+            return action(false)
+        }
     }
 }

--- a/LoopTests/FeedbackLoopSystemTests.swift
+++ b/LoopTests/FeedbackLoopSystemTests.swift
@@ -7,7 +7,7 @@ class FeedbackLoopSystemTests: XCTestCase {
 
     func test_emits_initial() {
         let initial = "initial"
-        let feedback = FeedbackLoop<String, String>.Feedback { state in
+        let feedback = Loop<String, String>.Feedback { state in
             return SignalProducer(value: "_a")
         }
         let system = SignalProducer<String, Never>.feedbackLoop(
@@ -22,7 +22,7 @@ class FeedbackLoopSystemTests: XCTestCase {
     }
 
     func test_reducer_with_one_feedback_loop() {
-        let feedback = FeedbackLoop<String, String>.Feedback { state in
+        let feedback = Loop<String, String>.Feedback { state in
             return SignalProducer(value: "_a")
         }
         let system = SignalProducer<String, Never>.feedbackLoop(
@@ -48,10 +48,10 @@ class FeedbackLoopSystemTests: XCTestCase {
     }
 
     func test_reduce_with_two_immediate_feedback_loops() {
-        let feedback1 = FeedbackLoop<String, String>.Feedback { state in
+        let feedback1 = Loop<String, String>.Feedback { state in
             return !state.hasSuffix("_a") ? SignalProducer(value: "_a") : .empty
         }
-        let feedback2 = FeedbackLoop<String, String>.Feedback { state in
+        let feedback2 = Loop<String, String>.Feedback { state in
             return !state.hasSuffix("_b") ? SignalProducer(value: "_b") : .empty
         }
         let system = SignalProducer<String, Never>.feedbackLoop(
@@ -80,7 +80,7 @@ class FeedbackLoopSystemTests: XCTestCase {
     }
 
     func test_reduce_with_async_feedback_loop() {
-        let feedback = FeedbackLoop<String, String>.Feedback { state -> SignalProducer<String, Never> in
+        let feedback = Loop<String, String>.Feedback { state -> SignalProducer<String, Never> in
             if state == "initial" {
                 return SignalProducer(value: "_a")
                     .delay(0.1, on: QueueScheduler.main)
@@ -125,7 +125,7 @@ class FeedbackLoopSystemTests: XCTestCase {
                 state += event
             },
             feedbacks: [
-                FeedbackLoop<String, String>.Feedback { state in
+                Loop<String, String>.Feedback { state in
                     return signal.producer
                 }
             ]
@@ -149,7 +149,7 @@ class FeedbackLoopSystemTests: XCTestCase {
                 state += event
             },
             feedbacks: [
-                FeedbackLoop<String, String>.Feedback { state -> SignalProducer<String, Never> in
+                Loop<String, String>.Feedback { state -> SignalProducer<String, Never> in
                     return SignalProducer(value: "_a")
                         .on(starting: { startCount += 1 })
                 }
@@ -181,7 +181,7 @@ class FeedbackLoopSystemTests: XCTestCase {
                         state += event
                     },
                     feedbacks: [
-                        FeedbackLoop<String, String>.Feedback { state, output in
+                        Loop<String, String>.Feedback { state, output in
                             state
                                 .take(first: 1)
                                 .map(value: "_event")
@@ -204,7 +204,7 @@ class FeedbackLoopSystemTests: XCTestCase {
             case increment
         }
         let (incrementSignal, incrementObserver) = Signal<Void, Never>.pipe()
-        let feedback = FeedbackLoop<Int, Event>.Feedback(predicate: { $0 < 2 }) { _ in
+        let feedback = Loop<Int, Event>.Feedback(predicate: { $0 < 2 }) { _ in
             incrementSignal.map { _ in Event.increment }
         }
         let system = SignalProducer<Int, Never>.feedbackLoop(
@@ -266,8 +266,8 @@ class FeedbackLoopSystemTests: XCTestCase {
                 }
             },
             feedbacks: [
-                FeedbackLoop.Feedback(source: increments, as: Event.increment(by:)),
-                FeedbackLoop.Feedback(source: workTrigger, as: { .timeConsumingWork })
+                Loop.Feedback(source: increments, as: Event.increment(by:)),
+                Loop.Feedback(source: workTrigger, as: { .timeConsumingWork })
             ]
         )
 
@@ -312,7 +312,7 @@ class FeedbackLoopSystemTests: XCTestCase {
                 state += event
             },
             feedbacks: [
-                FeedbackLoop.Feedback { state, output in
+                Loop.Feedback { state, output in
                     state
                         .take(first: 1)
                         .then(SignalProducer(value: 2))
@@ -334,5 +334,41 @@ class FeedbackLoopSystemTests: XCTestCase {
         }
 
         expect(results) == [0, 2, 1002, 2004, 4006]
+    }
+
+    func test_should_not_deadlock_when_feedback_effect_starts_loop_producer_synchronously() {
+        var _loop: Loop<Int, Int>!
+
+        let loop = Loop<Int, Int>(
+            initial: 0,
+            reducer: { $0 += $1 },
+            feedbacks: [
+                .init(
+                    skippingRepeated: { $0 == 1 },
+                    effects: { isOne in
+                        isOne
+                            ? _loop.producer.map(value: 1000).take(first: 1)
+                            : .empty
+                    }
+                )
+            ]
+        )
+        _loop = loop
+
+        var results: [Int] = []
+        loop.producer.startWithValues { results.append($0) }
+
+        expect(results) == [0]
+
+        func evaluate() {
+            loop.send(1)
+            expect(results) == [0, 1, 1001]
+        }
+
+        #if arch(x86_64)
+        expect(expression: evaluate).notTo(throwAssertion())
+        #else
+        evaluate()
+        #endif
     }
 }


### PR DESCRIPTION
The deadlock is fixed by using a recursive lock, so that `Loop.producer` can be reentrant.

Having said that, event draining must remain non-reentrant, where reentrant calls must continue not to attempt to drain the event queue (otherwise it will lead to a deadlock in ReactiveSwift, as `Signal` bans recursive value delivery). So refactoring is done in `Floodgate` to deal with reentrancy appropriately for the event queue.

Also added the then-failing test case.