### PR TITLE
Create scoped store that zooms only on the event type, and ignore/disable external event input completely

### DIFF
--- a/Loop/LoopBox.swift
+++ b/Loop/LoopBox.swift
@@ -2,7 +2,7 @@ import ReactiveSwift
 
 internal class ScopedLoopBox<RootState, RootEvent, ScopedState, ScopedEvent>: LoopBoxBase<ScopedState, ScopedEvent> {
     override var producer: SignalProducer<ScopedState, Never> {
-        root.producer.map(value)
+        root.producer.map(extract)
     }
 
     override var lifetime: Lifetime {
@@ -11,20 +11,20 @@ internal class ScopedLoopBox<RootState, RootEvent, ScopedState, ScopedEvent>: Lo
 
     /// Loop Internal SPI
     override var _current: ScopedState {
-        root._current[keyPath: value]
+        extract(root._current)
     }
 
     private let root: LoopBoxBase<RootState, RootEvent>
-    private let value: KeyPath<RootState, ScopedState>
+    private let extract: (RootState) -> ScopedState
     private let eventTransform: (ScopedEvent) -> RootEvent
 
     init(
         root: LoopBoxBase<RootState, RootEvent>,
-        value: KeyPath<RootState, ScopedState>,
+        value: @escaping (RootState) -> ScopedState,
         event: @escaping (ScopedEvent) -> RootEvent
     ) {
         self.root = root
-        self.value = value
+        self.extract = value
         self.eventTransform = event
     }
 
@@ -33,12 +33,14 @@ internal class ScopedLoopBox<RootState, RootEvent, ScopedState, ScopedEvent>: Lo
     }
 
     override func scoped<S, E>(
-        to scope: KeyPath<ScopedState, S>,
+        to scope: @escaping (ScopedState) -> S,
         event: @escaping (E) -> ScopedEvent
     ) -> LoopBoxBase<S, E> {
+        let extract = self.extract
+
         return ScopedLoopBox<RootState, RootEvent, S, E>(
             root: self.root,
-            value: value.appending(path: scope),
+            value: { scope(extract($0)) },
             event: { [eventTransform] in eventTransform(event($0)) }
         )
     }
@@ -75,7 +77,7 @@ internal class RootLoopBox<State, Event>: LoopBoxBase<State, Event> {
     }
 
     override func scoped<S, E>(
-        to scope: KeyPath<State, S>,
+        to scope: @escaping (State) -> S,
         event: @escaping (E) -> Event
     ) -> LoopBoxBase<S, E> {
         ScopedLoopBox(root: self, value: scope, event: event)
@@ -108,7 +110,7 @@ internal class LoopBoxBase<State, Event> {
     func send(_ event: Event) { subclassMustImplement() }
 
     func scoped<S, E>(
-        to scope: KeyPath<State, S>,
+        to scope: @escaping (State) -> S,
         event: @escaping (E) -> Event
     ) -> LoopBoxBase<S, E> {
         subclassMustImplement()

--- a/Loop/Public/Loop.swift
+++ b/Loop/Public/Loop.swift
@@ -62,7 +62,9 @@ public final class Loop<State, Event> {
         )
     }
 
-    public func eraseEventType() -> Loop<State, Never> {
+    /// Create a scoped `Loop` from `self` which will not accept any input from `Loop.send(_:)`. Note that sending
+    /// events on `self` through `Loop.send(_:)` remains unaffected.
+    public func ignoringInput() -> Loop<State, Never> {
         return Loop<State, Never>(
             box: box.scoped(to: { $0 }, event: { _ in fatalError() })
         )

--- a/Loop/Public/Loop.swift
+++ b/Loop/Public/Loop.swift
@@ -46,11 +46,25 @@ public final class Loop<State, Event> {
     }
 
     public func scoped<ScopedState, ScopedEvent>(
-        to scope: KeyPath<State, ScopedState>,
+        to scope: @escaping (State) -> ScopedState,
         event: @escaping (ScopedEvent) -> Event
     ) -> Loop<ScopedState, ScopedEvent> {
         return Loop<ScopedState, ScopedEvent>(
             box: box.scoped(to: scope, event: event)
+        )
+    }
+
+    public func scoped<ScopedEvent>(
+        event: @escaping (ScopedEvent) -> Event
+    ) -> Loop<State, ScopedEvent> {
+        return Loop<State, ScopedEvent>(
+            box: box.scoped(to: { $0 }, event: event)
+        )
+    }
+
+    public func eraseEventType() -> Loop<State, Never> {
+        return Loop<State, Never>(
+            box: box.scoped(to: { $0 }, event: { _ in fatalError() })
         )
     }
 }
@@ -73,7 +87,7 @@ extension Loop {
         value: KeyPath<State, ScopedState>,
         event: @escaping (ScopedEvent) -> Event
     ) -> Loop<ScopedState, ScopedEvent> {
-        return scoped(to: value, event: event)
+        return scoped(to: { $0[keyPath: value] }, event: event)
     }
 
     @available(*, unavailable, message:"Loop now starts automatically.")

--- a/Loop/Public/SwiftUI/LoopBinding.swift
+++ b/Loop/Public/SwiftUI/LoopBinding.swift
@@ -39,7 +39,7 @@ public struct LoopBinding<State, Event>: DynamicProperty {
     }
 
     public func scoped<ScopedState, ScopedEvent>(
-        to value: KeyPath<State, ScopedState>,
+        to value: @escaping (State) -> ScopedState,
         event: @escaping (ScopedEvent) -> Event
     ) -> LoopBinding<ScopedState, ScopedEvent> {
         LoopBinding<ScopedState, ScopedEvent>(loop.scoped(to: value, event: event))


### PR DESCRIPTION
Introduce the convenience to scope only the event type:

```swift
enum WeatherUserAction {
  case refresh, retry, ...
}

enum WeatherEvent {
  case didFetch, ...
  case user(WeatherUserAction)
}

let internalLoop: Loop<WeatherState, WeatherEvent>

let state = internalLoop.scoped(event: WeatherEvent.user)
print(type(of: state)) // OUT: Loop<WeatherState, WeatherUserAction>
```

Also a convenience to erase the event type to `Never` completely:

```swift
let internalLoop: Loop<WeatherState, WeatherEvent>

let state = internalLoop.ignoringInput()
print(type(of: state)) // OUT: Loop<WeatherState, Never>
```