### PR TITLE
Deprecate and introduce some new feedback variants

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -68,7 +68,6 @@
 		5BC88F9D246B1CDE00394C63 /* SignalProducer+Loop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC88F9B246B1CDE00394C63 /* SignalProducer+Loop.swift */; };
 		5BC88F9E246B1CDE00394C63 /* SignalProducer+Loop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC88F9B246B1CDE00394C63 /* SignalProducer+Loop.swift */; };
 		5BDEDA3B2473357A00A13013 /* EnvironmentLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8F92132473250E00C1C90E /* EnvironmentLoop.swift */; };
-		5BDEDA3C2473357A00A13013 /* EnvironmentLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8F92132473250E00C1C90E /* EnvironmentLoop.swift */; };
 		5BDEDA3D2473357B00A13013 /* EnvironmentLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8F92132473250E00C1C90E /* EnvironmentLoop.swift */; };
 		5BDEDA3E2473359C00A13013 /* EnvironmentValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8F921B247325C300C1C90E /* EnvironmentValues.swift */; };
 		5BDEDA3F2473359D00A13013 /* EnvironmentValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8F921B247325C300C1C90E /* EnvironmentValues.swift */; };
@@ -99,6 +98,10 @@
 		65F8C2972183725900924657 /* Loop.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25CC87AE1F92855300A6EBFC /* Loop.framework */; };
 		65F8C2CF218378F500924657 /* Loop.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65F8C26B218371A800924657 /* Loop.framework */; };
 		65F8C2D0218378F500924657 /* Loop.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 65F8C26B218371A800924657 /* Loop.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9A01A42824BC78E200075A57 /* FeedbackVariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A01A42724BC78E200075A57 /* FeedbackVariantTests.swift */; };
+		9A01A42924BC78E200075A57 /* FeedbackVariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A01A42724BC78E200075A57 /* FeedbackVariantTests.swift */; };
+		9A01A42A24BC78E200075A57 /* FeedbackVariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A01A42724BC78E200075A57 /* FeedbackVariantTests.swift */; };
+		9A01A42B24BC7E2E00075A57 /* EnvironmentLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8F92132473250E00C1C90E /* EnvironmentLoop.swift */; };
 		9AD5D42D1F97375E00E6AE5A /* Property+System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD5D42C1F97375E00E6AE5A /* Property+System.swift */; };
 		9AE181BB1F95A71B00A07551 /* Loop.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25CC87AE1F92855300A6EBFC /* Loop.framework */; };
 		9AE9563E2186341B005A8C69 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AE9563B21863415005A8C69 /* ReactiveCocoa.framework */; };
@@ -248,6 +251,7 @@
 		65F8C27A218371AC00924657 /* Loop.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Loop.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65F8C28E2183723F00924657 /* LoopTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoopTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		65F8C2A22183725900924657 /* LoopTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoopTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A01A42724BC78E200075A57 /* FeedbackVariantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackVariantTests.swift; sourceTree = "<group>"; };
 		9AD5D42C1F97375E00E6AE5A /* Property+System.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Property+System.swift"; sourceTree = "<group>"; };
 		9AE181B61F95A71B00A07551 /* LoopTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoopTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9AE181BA1F95A71B00A07551 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -520,6 +524,7 @@
 				5898B6D01F97ADDD005EEAEC /* SystemTests.swift */,
 				9AE181BA1F95A71B00A07551 /* Info.plist */,
 				250B70DE23FC441300848429 /* FeedbackLoopSystemTests.swift */,
+				9A01A42724BC78E200075A57 /* FeedbackVariantTests.swift */,
 			);
 			path = LoopTests;
 			sourceTree = "<group>";
@@ -876,6 +881,7 @@
 				5BC88F9D246B1CDE00394C63 /* SignalProducer+Loop.swift in Sources */,
 				5BC88F93246B17B200394C63 /* Context.swift in Sources */,
 				5BAB9751247FFBC10079B532 /* SwiftUIHotSwappableSubscription.swift in Sources */,
+				9A01A42B24BC7E2E00075A57 /* EnvironmentLoop.swift in Sources */,
 				585CD87C239E6A3E004BE9CC /* Reducer.swift in Sources */,
 				65F8C262218371A800924657 /* Property+System.swift in Sources */,
 				5BC88F89246AFC5900394C63 /* ReactiveSwift+EnqueueTo.swift in Sources */,
@@ -886,7 +892,6 @@
 				5BC88F8F246B11DE00394C63 /* LoopBox.swift in Sources */,
 				65761B2723CF20EF004D5506 /* Floodgate.swift in Sources */,
 				5BC88F99246B191200394C63 /* Loop.swift in Sources */,
-				5BDEDA3C2473357A00A13013 /* EnvironmentLoop.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -919,6 +924,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A01A42924BC78E200075A57 /* FeedbackVariantTests.swift in Sources */,
 				65F8C2802183723F00924657 /* SystemTests.swift in Sources */,
 				250B70E023FC441300848429 /* FeedbackLoopSystemTests.swift in Sources */,
 			);
@@ -928,6 +934,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A01A42A24BC78E200075A57 /* FeedbackVariantTests.swift in Sources */,
 				65F8C2942183725900924657 /* SystemTests.swift in Sources */,
 				250B70E123FC441300848429 /* FeedbackLoopSystemTests.swift in Sources */,
 			);
@@ -937,6 +944,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A01A42824BC78E200075A57 /* FeedbackVariantTests.swift in Sources */,
 				5898B6D11F97ADDD005EEAEC /* SystemTests.swift in Sources */,
 				250B70DF23FC441300848429 /* FeedbackLoopSystemTests.swift in Sources */,
 			);

--- a/Loop/Public/FeedbackLoop.swift
+++ b/Loop/Public/FeedbackLoop.swift
@@ -295,7 +295,7 @@ extension Loop {
             Feedback(extractingPayload: transform, effects: effects)
         }
 
-        /// Create a feedback which (re)starts the effect every time `transform` emits a non-nil value after a sequence
+        /// Create a Feedback which (re)starts the effect every time `transform` emits a non-nil value after a sequence
         /// of `nil`, and ignore all the non-nil value afterwards. It does so until `transform` starts emitting a `nil`,
         /// at which point the feedback cancels any outstanding effect.
         ///
@@ -354,7 +354,44 @@ extension Loop {
         ) -> Feedback where Effect.Value == Event, Effect.Error == Never {
             self.init(firstValueAfterNil: transform, effects: effects)
         }
-        
+
+        /// Creates a Feedback which evaluates the given effect when the predicate transitions to `true`, and
+        /// cancels the outstanding effect when the predicate transitions to `false`.
+        ///
+        /// In other words, this variant treats the output of `predicate` as a binary signal. It starts the effect when
+        /// there is a positive edge, and cancels the outstanding effect (if any) when there is a negative edge.
+        ///
+        /// - parameters:
+        ///   - predicate: The predicate to indicate whether effects should start or be cancelled.
+        ///   - effects: The side effect accepting the state and yielding events that eventually affect the state.
+        public init<Effect: SignalProducerConvertible>(
+            whenBecomesTrue predicate: @escaping (State) -> Bool,
+            effects: @escaping (State) -> Effect
+        ) where Effect.Value == Event, Effect.Error == Never {
+            self.init(
+                firstValueAfterNil: { predicate($0) ? $0 : nil },
+                effects: { state -> SignalProducer<Event, Never> in
+                    effects(state).producer
+                }
+            )
+        }
+
+        /// Creates a Feedback which evaluates the given effect when the predicate transitions to `true`, and
+        /// cancels the outstanding effect when the predicate transitions to `false`.
+        ///
+        /// In other words, this variant treats the output of `predicate` as a binary signal. It starts the effect when
+        /// there is a positive edge, and cancels the outstanding effect (if any) when there is a negative edge.
+        ///
+        /// - parameters:
+        ///   - predicate: The predicate to indicate whether effects should start or be cancelled.
+        ///   - effects: The side effect accepting the state and yielding events that eventually affect the state.
+        public static func whenBecomesTrue<Effect: SignalProducerConvertible>(
+            _ predicate: @escaping (State) -> Bool,
+            effects: @escaping (State) -> Effect
+        ) -> Feedback where Effect.Value == Event, Effect.Error == Never {
+            self.init(whenBecomesTrue: predicate, effects: effects)
+        }
+
         /// Creates a Feedback which re-evaluates the given effect every time the
         /// state changes with the Event that caused the change.
         ///

--- a/LoopTests/FeedbackVariantTests.swift
+++ b/LoopTests/FeedbackVariantTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+import Nimble
+import ReactiveSwift
+@testable import Loop
+
+class FeedbackVariantTests: XCTestCase {
+    func test_whenBecomesTrue_positive_edge() {
+        var receivedValues: [String] = []
+
+        let loop = Loop<String, String>(
+            initial: "",
+            reducer: { content, string in
+                content.append(contentsOf: string)
+            },
+            feedbacks: [
+                .whenBecomesTrue(
+                    { $0.hasSuffix("_") },
+                    effects: { state -> SignalProducer<String, Never> in
+                        receivedValues.append(state)
+
+                        return SignalProducer(value: "feedback_")
+                    }
+                )
+            ]
+        )
+
+        expect(loop.box._current) == ""
+
+        loop.send("hello")
+        expect(loop.box._current) == "hello"
+        expect(receivedValues.last).to(beNil())
+
+        // This should trigger a positive edge in `whenBecomesTrue`.
+        loop.send("_")
+        expect(loop.box._current) == "hello_feedback_"
+        expect(receivedValues.last) == "hello_"
+
+        // The predicate stays `true`, so no transition should occur.
+        loop.send("_")
+        expect(loop.box._current) == "hello_feedback__"
+        expect(receivedValues.last) == "hello_"
+
+        // This should lead to a negative edge.
+        loop.send("world")
+        expect(loop.box._current) == "hello_feedback__world"
+        expect(receivedValues.last) == "hello_"
+
+        // This should trigger a positive edge again in `whenBecomesTrue`.
+        loop.send("_")
+        expect(loop.box._current) == "hello_feedback__world_feedback_"
+        expect(receivedValues.last) == "hello_feedback__world_"
+    }
+
+    func test_whenBecomesTrue_negative_edge() {
+        var hasStarted = false
+        var hasCancelled = false
+
+        let loop = Loop<String, String>(
+            initial: "",
+            reducer: { content, string in
+                content.append(contentsOf: string)
+            },
+            feedbacks: [
+                .whenBecomesTrue(
+                    { $0.hasSuffix("_") },
+                    effects: { _ in
+                        SignalProducer.never
+                            .on(started: { hasStarted = true })
+                            .on(disposed: { hasCancelled = true })
+                    }
+                )
+            ]
+        )
+
+        expect(loop.box._current) == ""
+        expect(hasStarted) == false
+
+        // This should trigger a positive edge in `whenBecomesTrue`.
+        loop.send("_")
+        expect(hasStarted) == true
+        expect(hasCancelled) == false
+
+        loop.send("_")
+        expect(hasCancelled) == false
+
+        loop.send("_")
+        expect(hasCancelled) == false
+
+        // This should lead to a negative edge, which in turn should cancel the effect.
+        loop.send("word")
+        expect(hasCancelled) == true
+    }
+
+    func test_firstValueAfterNil_positive_edge() {
+        var receivedValues: [String] = []
+
+        let loop = Loop<String, String>(
+            initial: "",
+            reducer: { content, string in
+                content = string
+            },
+            feedbacks: [
+                .firstValueAfterNil(
+                    { $0.hasPrefix("hello") ? $0 : nil },
+                    effects: { state -> SignalProducer<String, Never> in
+                        receivedValues.append(state)
+
+                        return SignalProducer(value: "\(String(repeating: state, count: 2))")
+                    }
+                )
+            ]
+        )
+
+        expect(loop.box._current) == ""
+        expect(receivedValues.last).to(beNil())
+
+        // This should trigger a positive edge in `firstValueAfterNil`.
+        loop.send("hello#")
+        expect(loop.box._current) == "hello#hello#"
+        expect(receivedValues.last) == "hello#"
+
+        // The transform output stays non-nil, so no transition should occur.
+        loop.send("hello_world")
+        expect(loop.box._current) == "hello_world"
+        expect(receivedValues.last) == "hello#"
+
+        // This should lead to a negative edge.
+        loop.send("goodbye")
+        expect(loop.box._current) == "goodbye"
+        expect(receivedValues.last) == "hello#"
+
+        // This should trigger a positive edge again in `firstValueAfterNil`.
+        loop.send("hello_it_is_me#")
+        expect(loop.box._current) == "hello_it_is_me#hello_it_is_me#"
+        expect(receivedValues.last) == "hello_it_is_me#"
+    }
+
+    func test_firstValueAfterNil_negative_edge() {
+        var hasStarted = false
+        var hasCancelled = false
+
+        let loop = Loop<String, String>(
+            initial: "",
+            reducer: { content, string in
+                content = string
+            },
+            feedbacks: [
+                .firstValueAfterNil(
+                    { $0.hasPrefix("hello") ? $0 : nil },
+                    effects: { _ in
+                        SignalProducer.never
+                            .on(started: { hasStarted = true })
+                            .on(disposed: { hasCancelled = true })
+                    }
+                )
+            ]
+        )
+
+        expect(loop.box._current) == ""
+        expect(hasStarted) == false
+
+        // This should trigger a positive edge in `whenBecomesTrue`.
+        loop.send("hello1")
+        expect(hasStarted) == true
+        expect(hasCancelled) == false
+
+        loop.send("hello2")
+        expect(hasCancelled) == false
+
+        loop.send("hello3")
+        expect(hasCancelled) == false
+
+        // This should lead to a negative edge, which in turn should cancel the effect.
+        loop.send("world")
+        expect(hasCancelled) == true
+    }
+}


### PR DESCRIPTION
Pick up again [the plan to deprecate `Feedback(predicate:effects:)`](https://github.com/babylonhealth/ReactiveFeedback/pull/55).

This PR deprecates:
* `Feedback.init(effects:)`
* `Feedback.init(predicate:effects:)`

and replace them with:
* `Feedback.init(whenBecomesTrue:effects:)`
* `Feedback.init(firstValueAfterNil:effects:)`

The experience of RAF/Loop production use has supported well that the replacements here have more desirable semantics. They also support real world use cases better, especially when the state is a product type value with states often only being partially invalidated.

The old variants would have aggressively recreating/cancelling effects every time the state is updated, even though logically it is meant to react to only a part of the state. For example, a "when loading" feedback probably cares only about `state.status == .loading`. But if it is implemented with `Feedback.init(effects:)` or `Feedback.init(predicate:effects:)`, the effect is recreated for every occurrence of state update, even when `state.status == .loading` holds true continuously.

Users who really want these deprecated semantics can still have them manually via the primitive `Feedback.init` or `Feedback.init(compacting:effects:)`.


- [x] Unit tests