### PR TITLE
Fix firstValueAfterNil not starting effects when initial state gives non-nil transformed value

### DIFF
--- a/Loop/Public/FeedbackLoop.swift
+++ b/Loop/Public/FeedbackLoop.swift
@@ -311,7 +311,7 @@ extension Loop {
           self.init(
             compacting: { state in
               state
-                .scan(into: (false, nil)) { (temp: inout (lastWasNil: Bool, output: NilEdgeTransition<Value>?), state: State) in
+                .scan(into: (true, nil)) { (temp: inout (lastWasNil: Bool, output: NilEdgeTransition<Value>?), state: State) in
                   let result = transform(state)
                   temp.output = nil
 


### PR DESCRIPTION
Fix the effect not being started in either of these two scenarios:

1. Given the `firstValueAfterNil` transform, the initial state gives a non-nil transformed value.
2. Given the `whenBecomesTrue` predicate, the initial state satisfies the predicate.

