### PR TITLE
Require ReactiveSwift 7.0, uniformize deployment targets

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveCocoa/ReactiveSwift" ~> 6.0
+github "ReactiveCocoa/ReactiveSwift" ~> 7.0

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,5 +1,5 @@
 # Example app.
-github "ReactiveCocoa/ReactiveCocoa" ~> 10.0.0
+github "ReactiveCocoa/ReactiveCocoa" ~> 12.0.0
 
 # Tests
-github "Quick/Nimble" ~> 8.0
+github "Quick/Nimble" ~> 9.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v8.1.1"
-github "ReactiveCocoa/ReactiveCocoa" "10.3.0"
-github "ReactiveCocoa/ReactiveSwift" "6.3.0"
+github "Quick/Nimble" "v9.2.1"
+github "ReactiveCocoa/ReactiveCocoa" "12.0.0"
+github "ReactiveCocoa/ReactiveSwift" "7.1.0"

--- a/Loop.podspec
+++ b/Loop.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   s.cocoapods_version = ">= 1.7.0"
   s.swift_versions = ["5.2"]
 
-  s.dependency "ReactiveSwift", "~> 6.2"
+  s.dependency "ReactiveSwift", "~> 7.0"
 end

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -1075,15 +1075,15 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -1129,13 +1129,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1188,6 +1188,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Loop/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactivecocoa.Loop;
 				PRODUCT_NAME = Loop;
@@ -1209,6 +1210,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Loop/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactivecocoa.Loop;
 				PRODUCT_NAME = Loop;
@@ -1270,6 +1272,7 @@
 					"$(BUILT_PRODUCTS_DIR)/Nimble",
 				);
 				INFOPLIST_FILE = LoopTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks @loader_path/Frameworks @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactivecocoa.LoopTests;
 				PRODUCT_NAME = LoopTests;
@@ -1288,6 +1291,7 @@
 					"$(BUILT_PRODUCTS_DIR)/Nimble",
 				);
 				INFOPLIST_FILE = LoopTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks @loader_path/Frameworks @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactivecocoa.LoopTests;
 				PRODUCT_NAME = LoopTests;

--- a/LoopTests/FeedbackLoopSystemTests.swift
+++ b/LoopTests/FeedbackLoopSystemTests.swift
@@ -373,7 +373,7 @@ class FeedbackLoopSystemTests: XCTestCase {
         }
 
         #if arch(x86_64)
-        expect(expression: evaluate).notTo(throwAssertion())
+        expect(evaluate).notTo(throwAssertion())
         #else
         evaluate()
         #endif

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift",
         "state": {
           "branch": null,
-          "revision": "3f4351d04115fd8797802d9b2d17b812cd761602",
-          "version": "6.3.0"
+          "revision": "509916c99f49a5e6c8196c968b8b7e3dbd48db04",
+          "version": "7.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,14 @@ import PackageDescription
 
 let package = Package(
     name: "Loop",
+    platforms: [
+        .macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v4)
+    ],
     products: [
         .library(name: "Loop", targets: ["Loop"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", from: "6.0.0"),
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", from: "7.0.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.0"),
     ],
     targets: [

--- a/script/carthage
+++ b/script/carthage
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Adopted from https://github.com/Carthage/Carthage/issues/3019#issuecomment-665136323
+
+# carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12+ make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+XCODE_VERSION_MAJ=1300 # should mirror XCODE_VERSION_MAJOR - update accordingly
+
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_${XCODE_VERSION_MAJ} = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"


### PR DESCRIPTION
## Changes

- Require ReactiveSwift 7.0.

- Update ReactiveCocoa to 12.0 for the example app.

- Uniformize deployment targets in podspec, Package.swift and Xcode project (from podspec).

- Add carthage shell script to enable building with Carthage in Xcode 13+.

- Bump Nimble to 9.0 to work around `-lswiftXCTest` link issue https://github.com/Quick/Nimble/issues/855.